### PR TITLE
♻️ refactor: rename project from cisco-quiz-app to CertQuiz

### DIFF
--- a/.claude/instructions.md
+++ b/.claude/instructions.md
@@ -14,7 +14,7 @@
 
 ## Project Context
 
-You are implementing a Cisco Quiz Application. The main context is in `/CLAUDE.md` at the project root. Always read that first.
+You are implementing CertQuiz - a technical certification quiz application. The main context is in `/CLAUDE.md` at the project root. Always read that first.
 
 ## Implementation Approach
 
@@ -40,7 +40,7 @@ You are implementing a Cisco Quiz Application. The main context is in `/CLAUDE.m
 ```typescript
 // Import order
 1. External packages
-2. Internal packages (@cisco-quiz/*)
+2. Internal packages (@certquiz/*)
 3. Relative imports
 4. Type imports
 ```

--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,10 @@
 # Database Configuration
-DATABASE_URL=postgresql://postgres:password@localhost:5432/cisco_quiz
+DATABASE_URL=postgresql://postgres:password@localhost:5432/certquiz
 REDIS_URL=redis://localhost:6379
 
 # Authentication - KeyCloak
 KEYCLOAK_URL=http://localhost:8080
-KEYCLOAK_REALM=cisco-quiz
+KEYCLOAK_REALM=certquiz
 
 # Security
 # Generate a secure JWT secret key (minimum 16 characters)

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
         "bunx",
         "CCIE",
         "CCNP",
+        "certquiz",
         "Elysia",
         "elysiajs",
         "fdisk",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
-# Cisco Quiz App
+# CertQuiz
 
-A web-based quiz application for Cisco certification exam preparation (CCNP, CCIE). Built with modern TypeScript stack emphasizing type safety and developer experience.
+A web-based quiz application for technical certification exam preparation. Built with modern TypeScript stack emphasizing type safety and developer experience. Supports multiple exam types including CCNA, CCNP ENCOR, CCNP ENARSI, and other technical certifications.
 
 ## Core Development Principles
 
@@ -132,12 +132,12 @@ See @docs/task-list.md for detailed implementation tasks.
 Required in `.env`:
 ```env
 # Database
-DATABASE_URL=postgresql://postgres:password@localhost:5432/cisco_quiz
+DATABASE_URL=postgresql://postgres:password@localhost:5432/certquiz
 REDIS_URL=redis://localhost:6379
 
 # Authentication
 KEYCLOAK_URL=http://localhost:8080
-KEYCLOAK_REALM=cisco-quiz
+KEYCLOAK_REALM=certquiz
 JWT_SECRET=<generate-secure-key>
 
 # External Services

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Cisco Quiz App
+# CertQuiz
 
-A modern web application for Cisco certification exam preparation (CCNP, CCIE), built with TypeScript and emphasizing test-driven development.
+A modern web application for technical certification exam preparation, built with TypeScript and emphasizing test-driven development. Supports various technical certifications including networking, security, and cloud computing exams.
 
 ## 🚀 Quick Start
 
@@ -9,7 +9,7 @@ A modern web application for Cisco certification exam preparation (CCNP, CCIE), 
 
 # Clone and install
 git clone <repository-url>
-cd cisco-quiz-app
+cd cert-quiz
 bun install
 
 # Start services
@@ -35,7 +35,7 @@ KeyCloak: http://localhost:8080
 ## 📁 Project Structure
 
 ```
-cisco-quiz-app/
+cert-quiz/
 ├── apps/
 │   ├── web/          # SvelteKit frontend
 │   └── api/          # Elysia backend API
@@ -116,9 +116,9 @@ bun run docker:down      # Stop services
 
 Create `.env` file:
 ```env
-DATABASE_URL=postgresql://postgres:password@localhost:5432/cisco_quiz
+DATABASE_URL=postgresql://postgres:password@localhost:5432/certquiz
 KEYCLOAK_URL=http://localhost:8080
-KEYCLOAK_REALM=cisco-quiz
+KEYCLOAK_REALM=certquiz
 JWT_SECRET=<generate-secure-key>
 BMAC_WEBHOOK_SECRET=<from-buy-me-a-coffee>
 ```

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@cisco-quiz/api",
+  "name": "@certquiz/api",
   "version": "1.0.0",
   "type": "module",
   "scripts": {
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@cisco-quiz/shared": "workspace:*",
+    "@certquiz/shared": "workspace:*",
     "@elysiajs/cors": "^0.8.0",
     "@elysiajs/jwt": "^0.8.0",
     "@elysiajs/swagger": "^0.8.0",

--- a/apps/api/src/config/env.test.ts
+++ b/apps/api/src/config/env.test.ts
@@ -18,9 +18,9 @@ describe('Environment Configuration', () => {
     it('should validate all required environment variables', () => {
       process.env = {
         ...process.env,
-        DATABASE_URL: 'postgresql://postgres:password@localhost:5432/cisco_quiz',
+        DATABASE_URL: 'postgresql://postgres:password@localhost:5432/certquiz',
         KEYCLOAK_URL: 'http://localhost:8080',
-        KEYCLOAK_REALM: 'cisco-quiz',
+        KEYCLOAK_REALM: 'certquiz',
         JWT_SECRET: 'test-secret-key-with-minimum-length',
         BMAC_WEBHOOK_SECRET: 'test-webhook-secret',
         API_PORT: '4000',
@@ -35,9 +35,9 @@ describe('Environment Configuration', () => {
       
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.data.DATABASE_URL).toBe('postgresql://postgres:password@localhost:5432/cisco_quiz');
+        expect(result.data.DATABASE_URL).toBe('postgresql://postgres:password@localhost:5432/certquiz');
         expect(result.data.KEYCLOAK_URL).toBe('http://localhost:8080');
-        expect(result.data.KEYCLOAK_REALM).toBe('cisco-quiz');
+        expect(result.data.KEYCLOAK_REALM).toBe('certquiz');
         expect(result.data.JWT_SECRET).toBe('test-secret-key-with-minimum-length');
         expect(result.data.BMAC_WEBHOOK_SECRET).toBe('test-webhook-secret');
         expect(result.data.API_PORT).toBe(4000);
@@ -47,7 +47,7 @@ describe('Environment Configuration', () => {
 
     it('should fail when required environment variables are missing', () => {
       process.env = {
-        DATABASE_URL: 'postgresql://postgres:password@localhost:5432/cisco_quiz',
+        DATABASE_URL: 'postgresql://postgres:password@localhost:5432/certquiz',
         // Missing other required variables
       };
 
@@ -62,9 +62,9 @@ describe('Environment Configuration', () => {
 
     it('should use default values for optional variables', () => {
       process.env = {
-        DATABASE_URL: 'postgresql://postgres:password@localhost:5432/cisco_quiz',
+        DATABASE_URL: 'postgresql://postgres:password@localhost:5432/certquiz',
         KEYCLOAK_URL: 'http://localhost:8080',
-        KEYCLOAK_REALM: 'cisco-quiz',
+        KEYCLOAK_REALM: 'certquiz',
         JWT_SECRET: 'test-secret-key-with-minimum-length',
         BMAC_WEBHOOK_SECRET: 'test-webhook-secret',
         // API_PORT not provided, should use default
@@ -87,7 +87,7 @@ describe('Environment Configuration', () => {
       process.env = {
         DATABASE_URL: 'invalid-database-url',
         KEYCLOAK_URL: 'http://localhost:8080',
-        KEYCLOAK_REALM: 'cisco-quiz',
+        KEYCLOAK_REALM: 'certquiz',
         JWT_SECRET: 'test-secret-key-with-minimum-length',
         BMAC_WEBHOOK_SECRET: 'test-webhook-secret',
       };
@@ -102,9 +102,9 @@ describe('Environment Configuration', () => {
 
     it('should validate KEYCLOAK_URL format', () => {
       process.env = {
-        DATABASE_URL: 'postgresql://postgres:password@localhost:5432/cisco_quiz',
+        DATABASE_URL: 'postgresql://postgres:password@localhost:5432/certquiz',
         KEYCLOAK_URL: 'not-a-url',
-        KEYCLOAK_REALM: 'cisco-quiz',
+        KEYCLOAK_REALM: 'certquiz',
         JWT_SECRET: 'test-secret-key-with-minimum-length',
         BMAC_WEBHOOK_SECRET: 'test-webhook-secret',
       };
@@ -119,9 +119,9 @@ describe('Environment Configuration', () => {
 
     it('should validate API_PORT is a valid number', () => {
       process.env = {
-        DATABASE_URL: 'postgresql://postgres:password@localhost:5432/cisco_quiz',
+        DATABASE_URL: 'postgresql://postgres:password@localhost:5432/certquiz',
         KEYCLOAK_URL: 'http://localhost:8080',
-        KEYCLOAK_REALM: 'cisco-quiz',
+        KEYCLOAK_REALM: 'certquiz',
         JWT_SECRET: 'test-secret-key-with-minimum-length',
         BMAC_WEBHOOK_SECRET: 'test-webhook-secret',
         API_PORT: 'not-a-number',
@@ -137,9 +137,9 @@ describe('Environment Configuration', () => {
 
     it('should require minimum JWT_SECRET length', () => {
       process.env = {
-        DATABASE_URL: 'postgresql://postgres:password@localhost:5432/cisco_quiz',
+        DATABASE_URL: 'postgresql://postgres:password@localhost:5432/certquiz',
         KEYCLOAK_URL: 'http://localhost:8080',
-        KEYCLOAK_REALM: 'cisco-quiz',
+        KEYCLOAK_REALM: 'certquiz',
         JWT_SECRET: 'short',
         BMAC_WEBHOOK_SECRET: 'test-webhook-secret',
       };
@@ -156,22 +156,22 @@ describe('Environment Configuration', () => {
   describe('loadEnv', () => {
     it('should load and return validated environment configuration', () => {
       process.env = {
-        DATABASE_URL: 'postgresql://postgres:password@localhost:5432/cisco_quiz',
+        DATABASE_URL: 'postgresql://postgres:password@localhost:5432/certquiz',
         KEYCLOAK_URL: 'http://localhost:8080',
-        KEYCLOAK_REALM: 'cisco-quiz',
+        KEYCLOAK_REALM: 'certquiz',
         JWT_SECRET: 'test-secret-key-with-minimum-length',
         BMAC_WEBHOOK_SECRET: 'test-webhook-secret',
         API_PORT: '5000',
         NODE_ENV: 'production',
-        FRONTEND_URL: 'https://quiz.example.com',
+        FRONTEND_URL: 'https://certquiz.example.com',
       };
 
       const config = loadEnv();
       
-      expect(config.DATABASE_URL).toBe('postgresql://postgres:password@localhost:5432/cisco_quiz');
+      expect(config.DATABASE_URL).toBe('postgresql://postgres:password@localhost:5432/certquiz');
       expect(config.API_PORT).toBe(5000);
       expect(config.NODE_ENV).toBe('production');
-      expect(config.FRONTEND_URL).toBe('https://quiz.example.com');
+      expect(config.FRONTEND_URL).toBe('https://certquiz.example.com');
       expect(config.isDevelopment).toBe(false);
       expect(config.isProduction).toBe(true);
       expect(config.isTest).toBe(false);
@@ -186,9 +186,9 @@ describe('Environment Configuration', () => {
     it('should set correct boolean flags for different environments', () => {
       // Test development
       process.env = {
-        DATABASE_URL: 'postgresql://postgres:password@localhost:5432/cisco_quiz',
+        DATABASE_URL: 'postgresql://postgres:password@localhost:5432/certquiz',
         KEYCLOAK_URL: 'http://localhost:8080',
-        KEYCLOAK_REALM: 'cisco-quiz',
+        KEYCLOAK_REALM: 'certquiz',
         JWT_SECRET: 'test-secret-key-with-minimum-length',
         BMAC_WEBHOOK_SECRET: 'test-webhook-secret',
         NODE_ENV: 'development',

--- a/apps/api/src/config/integration.test.ts
+++ b/apps/api/src/config/integration.test.ts
@@ -1,7 +1,26 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { env } from './env';
 
 describe('Environment Configuration Integration', () => {
+  const originalEnv = { ...process.env };
+  
+  beforeAll(() => {
+    // Set up test environment variables
+    process.env.DATABASE_URL = 'postgresql://postgres:password@localhost:5432/certquiz_test';
+    process.env.KEYCLOAK_URL = 'http://localhost:8080';
+    process.env.KEYCLOAK_REALM = 'certquiz';
+    process.env.JWT_SECRET = 'test-secret-key-with-minimum-length';
+    process.env.BMAC_WEBHOOK_SECRET = 'test-webhook-secret';
+    process.env.API_PORT = '4000';
+    process.env.NODE_ENV = 'test';
+    process.env.FRONTEND_URL = 'http://localhost:5173';
+  });
+  
+  afterAll(() => {
+    // Restore original environment
+    process.env = originalEnv;
+  });
+  
   it('should load environment variables through proxy', () => {
     // Test that env proxy provides access to all required variables
     expect(env.DATABASE_URL).toBeDefined();

--- a/apps/api/src/config/redis.ts
+++ b/apps/api/src/config/redis.ts
@@ -133,8 +133,8 @@ export function getRedisConfig(
   };
 
   // Apply environment-specific configuration
-  if (env.REDIS_URL) {
-    // REDIS_URL takes precedence
+  if (env.REDIS_URL !== undefined) {
+    // REDIS_URL takes precedence (even if empty string)
     const urlConfig = parseRedisUrl(env.REDIS_URL, activeLogger);
     Object.assign(baseConfig, urlConfig);
   } else {

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
-      '@cisco-quiz/shared': path.resolve(__dirname, '../../packages/shared/src')
+      '@certquiz/shared': path.resolve(__dirname, '../../packages/shared/src')
     }
   }
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@cisco-quiz/web",
+  "name": "@certquiz/web",
   "version": "1.0.0",
   "type": "module",
   "scripts": {
@@ -26,7 +26,7 @@
     "@types/node": "^20.10.0"
   },
   "dependencies": {
-    "@cisco-quiz/shared": "workspace:*",
+    "@certquiz/shared": "workspace:*",
     "bits-ui": "^0.17.0",
     "clsx": "^2.1.0",
     "tailwind-merge": "^2.2.0",

--- a/bun.lock
+++ b/bun.lock
@@ -2,7 +2,7 @@
   "lockfileVersion": 1,
   "workspaces": {
     "": {
-      "name": "cisco-quiz-app",
+      "name": "quiz-app",
       "dependencies": {
         "es-toolkit": "^1.39.5",
       },
@@ -19,10 +19,10 @@
       },
     },
     "apps/api": {
-      "name": "@cisco-quiz/api",
+      "name": "@certquiz/api",
       "version": "1.0.0",
       "dependencies": {
-        "@cisco-quiz/shared": "workspace:*",
+        "@certquiz/shared": "workspace:*",
         "@elysiajs/cors": "^0.8.0",
         "@elysiajs/jwt": "^0.8.0",
         "@elysiajs/swagger": "^0.8.0",
@@ -44,10 +44,10 @@
       },
     },
     "apps/web": {
-      "name": "@cisco-quiz/web",
+      "name": "@certquiz/web",
       "version": "1.0.0",
       "dependencies": {
-        "@cisco-quiz/shared": "workspace:*",
+        "@certquiz/shared": "workspace:*",
         "bits-ui": "^0.17.0",
         "clsx": "^2.1.0",
         "tailwind-merge": "^2.2.0",
@@ -69,7 +69,7 @@
       },
     },
     "packages/shared": {
-      "name": "@cisco-quiz/shared",
+      "name": "@certquiz/shared",
       "version": "1.0.0",
       "devDependencies": {
         "@types/bun": "latest",
@@ -78,7 +78,7 @@
       },
     },
     "packages/typespec": {
-      "name": "@cisco-quiz/typespec",
+      "name": "@certquiz/typespec",
       "version": "1.0.0",
       "devDependencies": {
         "@typespec/compiler": "latest",
@@ -115,13 +115,13 @@
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@0.2.3", "", {}, "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="],
 
-    "@cisco-quiz/api": ["@cisco-quiz/api@workspace:apps/api"],
+    "@certquiz/api": ["@certquiz/api@workspace:apps/api"],
 
-    "@cisco-quiz/shared": ["@cisco-quiz/shared@workspace:packages/shared"],
+    "@certquiz/shared": ["@certquiz/shared@workspace:packages/shared"],
 
-    "@cisco-quiz/typespec": ["@cisco-quiz/typespec@workspace:packages/typespec"],
+    "@certquiz/typespec": ["@certquiz/typespec@workspace:packages/typespec"],
 
-    "@cisco-quiz/web": ["@cisco-quiz/web@workspace:apps/web"],
+    "@certquiz/web": ["@certquiz/web@workspace:apps/web"],
 
     "@elysiajs/cors": ["@elysiajs/cors@0.8.0", "", { "peerDependencies": { "elysia": ">= 0.8.0" } }, "sha512-NADcOsokALRv4nljA5DYJPJdIJ7iwq+ouV5lH5W+hLgZRMYsfbKShg82QSmxd7BJQFuGSv2dIIF2dfG9ieUyng=="],
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
-      POSTGRES_DB: cisco_quiz
+      POSTGRES_DB: certquiz
     ports:
       - "5432:5432"
     volumes:

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,6 +1,6 @@
 # Architecture Decision Records
 
-This directory contains Architecture Decision Records (ADRs) for the Cisco Quiz App project.
+This directory contains Architecture Decision Records (ADRs) for the CertQuiz project.
 
 ## What is an ADR?
 

--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Architecture decisions for the Cisco Quiz App are documented as Architecture Decision Records (ADRs) following industry best practices.
+Architecture decisions for CertQuiz are documented as Architecture Decision Records (ADRs) following industry best practices.
 
 ## 📁 ADR Location
 

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document defines coding conventions and best practices for the Cisco Quiz App project. All code should follow these standards to ensure consistency and maintainability.
+This document defines coding conventions and best practices for the CertQuiz project. All code should follow these standards to ensure consistency and maintainability.
 
 ## General Principles
 
@@ -267,7 +267,7 @@ ALTER TABLE questions DROP COLUMN is_premium;
 <!-- ✅ Good: Script-first approach -->
 <script lang="ts">
   import { onMount } from 'svelte';
-  import type { Question } from '@cisco-quiz/shared/types';
+  import type { Question } from '@certquiz/shared/types';
   
   // Props
   export let question: Question;
@@ -310,7 +310,7 @@ ALTER TABLE questions DROP COLUMN is_premium;
 // ✅ Good: Typed stores
 // stores/auth.ts
 import { writable, derived } from 'svelte/store';
-import type { User } from '@cisco-quiz/shared/types';
+import type { User } from '@certquiz/shared/types';
 
 function createAuthStore() {
   const { subscribe, set, update } = writable<User | null>(null);

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -361,7 +361,7 @@ async function seed() {
 
   // Create admin user
   const [adminUser] = await db.insert(users).values({
-    email: 'admin@cisco-quiz.app',
+    email: 'admin@certquiz.app',
     username: 'admin',
     role: 'admin',
   }).returning();

--- a/docs/project-setup.md
+++ b/docs/project-setup.md
@@ -12,7 +12,7 @@
 ```bash
 # Clone and setup
 git clone <repository-url>
-cd quiz-app
+cd cert-quiz
 bun install
 bun run setup
 
@@ -30,8 +30,8 @@ cp .env.example .env
 
 # Edit .env with your values
 # Required variables:
-DATABASE_URL=postgresql://postgres:password@localhost:5432/cisco_quiz
-KEYCLOAK_REALM=cisco-quiz
+DATABASE_URL=postgresql://postgres:password@localhost:5432/certquiz
+KEYCLOAK_REALM=certquiz
 JWT_SECRET=generate-a-secure-random-string
 BMAC_WEBHOOK_SECRET=from-buy-me-a-coffee-dashboard
 ```
@@ -47,7 +47,7 @@ mkdir -p .claude docs scripts tests
 # Initialize workspaces
 cat > package.json << 'EOF'
 {
-  "name": "quiz-app",
+  "name": "cert-quiz",
   "private": true,
   "workspaces": ["apps/*", "packages/*"],
   "scripts": {
@@ -91,7 +91,7 @@ cd packages/shared
 
 cat > package.json << 'EOF'
 {
-  "name": "@cisco-quiz/shared",
+  "name": "@certquiz/shared",
   "version": "1.0.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -176,7 +176,7 @@ cd apps/api
 
 cat > package.json << 'EOF'
 {
-  "name": "@cisco-quiz/api",
+  "name": "@certquiz/api",
   "version": "1.0.0",
   "type": "module",
   "scripts": {
@@ -194,7 +194,7 @@ cat > package.json << 'EOF'
     "drizzle-orm": "^0.29.0",
     "postgres": "^3.4.0",
     "zod": "^3.22.0",
-    "@cisco-quiz/shared": "workspace:*"
+    "@certquiz/shared": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "latest",
@@ -222,7 +222,7 @@ const app = new Elysia()
   .use(swagger({
     documentation: {
       info: {
-        title: 'Cisco Quiz API',
+        title: 'CertQuiz API',
         version: '1.0.0'
       }
     }
@@ -266,7 +266,7 @@ bunx create-svelte@latest . --template=skeleton-ts --no-install
 
 cat > package.json << 'EOF'
 {
-  "name": "@cisco-quiz/web",
+  "name": "@certquiz/web",
   "version": "1.0.0",
   "type": "module",
   "scripts": {
@@ -290,7 +290,7 @@ cat > package.json << 'EOF'
     "postcss": "^8.4.0"
   },
   "dependencies": {
-    "@cisco-quiz/shared": "workspace:*",
+    "@certquiz/shared": "workspace:*",
     "bits-ui": "^0.17.0",
     "clsx": "^2.1.0",
     "tailwind-merge": "^2.2.0",
@@ -328,7 +328,7 @@ services:
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
-      POSTGRES_DB: cisco_quiz
+      POSTGRES_DB: certquiz
     ports:
       - "5432:5432"
     volumes:
@@ -378,7 +378,7 @@ cat > scripts/setup.sh << 'EOF'
 #!/bin/bash
 set -e
 
-echo "🚀 Starting Cisco Quiz App setup..."
+echo "🚀 Starting CertQuiz setup..."
 
 # Check prerequisites
 command -v bun >/dev/null 2>&1 || { echo "❌ Bun is required but not installed."; exit 1; }
@@ -441,8 +441,8 @@ cat > tsconfig.json << 'EOF'
     "isolatedModules": true,
     "noEmit": true,
     "paths": {
-      "@cisco-quiz/shared": ["./packages/shared/src"],
-      "@cisco-quiz/shared/*": ["./packages/shared/src/*"]
+      "@certquiz/shared": ["./packages/shared/src"],
+      "@certquiz/shared/*": ["./packages/shared/src/*"]
     }
   },
   "include": ["apps/*/src/**/*", "packages/*/src/**/*"],

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cisco-quiz-app",
+  "name": "cert-quiz",
   "private": true,
   "type": "module",
   "workspaces": ["apps/*", "packages/*"],

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@cisco-quiz/shared",
+  "name": "@certquiz/shared",
   "version": "1.0.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -108,7 +108,7 @@ export function apiError(code: string, message: string, details?: unknown): ApiR
     error: {
       code,
       message,
-      ...(details && { details }),
+      ...(details !== undefined ? { details } : {}),
     },
   };
 }

--- a/packages/typespec/package.json
+++ b/packages/typespec/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@cisco-quiz/typespec",
+  "name": "@certquiz/typespec",
   "version": "1.0.0",
   "private": true,
   "type": "module",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,8 +12,8 @@
     "isolatedModules": true,
     "noEmit": true,
     "paths": {
-      "@cisco-quiz/shared": ["./packages/shared/src"],
-      "@cisco-quiz/shared/*": ["./packages/shared/src/*"]
+      "@certquiz/shared": ["./packages/shared/src"],
+      "@certquiz/shared/*": ["./packages/shared/src/*"]
     }
   },
   "include": ["apps/*/src/**/*", "packages/*/src/**/*"],


### PR DESCRIPTION
## 📋 Description

This PR renames the entire project from `cisco-quiz-app` to `CertQuiz`, making it a more generic platform for various technical certification exams rather than being limited to Cisco certifications.

### 🎯 Purpose

The project was originally designed specifically for Cisco certifications (CCNA, CCNP, CCIE). This rename allows the platform to support a wider range of technical certifications including:
- Networking certifications (Cisco, Juniper, etc.)
- Cloud certifications (AWS, Azure, GCP)
- Security certifications (CompTIA Security+, etc.)
- Other IT certifications

### 🔄 Changes Made

1. **Package Names**: 
   - `@cisco-quiz/*` → `@certquiz/*`
   - Updated all package.json files and imports

2. **Database**: 
   - Database name: `cisco_quiz` → `certquiz`
   - KeyCloak realm: `cisco-quiz` → `certquiz`

3. **Project Identity**:
   - Project name: "Cisco Quiz App" → "CertQuiz"
   - Updated all documentation and references
   - Maintained exam type categorization (CCNA, CCNP ENCOR, etc.)

4. **Code Fixes**:
   - Fixed TypeScript spread operator issue in `apiError` function
   - Updated Redis config to handle empty URL strings
   - Added proper test environment setup for integration tests

### 💥 Breaking Changes

- **Package imports**: All imports must be updated from `@cisco-quiz/*` to `@certquiz/*`
- **Database name**: The database name has changed to `certquiz`
- **Environment variables**: Database URL and KeyCloak realm must be updated

### 📝 Migration Guide

For existing installations:

1. Update your `.env` file:
   ```env
   DATABASE_URL=postgresql://postgres:password@localhost:5432/certquiz
   KEYCLOAK_REALM=certquiz
   ```

2. Create new database or rename existing:
   ```sql
   ALTER DATABASE cisco_quiz RENAME TO certquiz;
   ```

3. Update all imports in your code from `@cisco-quiz/*` to `@certquiz/*`

### ✅ Checklist

#### General Requirements
- [x] **TDD followed**: Tests written BEFORE implementation
- [x] **Type safety**: No `any` types used
- [x] **Tests pass**: All 67 tests passing
- [x] **Documentation updated**: README, CLAUDE.md, and all docs updated

#### Configuration Changes
- [x] Environment variables updated (.env.example)
- [x] Docker configuration updated (docker-compose.yml)
- [x] TypeScript paths updated (tsconfig.json)
- [x] VS Code settings updated (added certquiz to dictionary)

#### Test Evidence
```bash
cd apps/api && NODE_ENV=test bun test --no-coverage

✓ Redis Connection Integration (12 tests)
✓ Environment Configuration (22 tests) 
✓ Redis Configuration (24 tests)
✓ Environment Configuration Integration (3 tests)
✓ Health Check Routes (6 tests)

67 pass
0 fail
```

### 🚀 Next Steps

After merging:
1. Update production environment variables
2. Rename production database
3. Update any CI/CD configurations
4. Update deployment scripts

### 📸 Screenshots

Not applicable for this configuration change.